### PR TITLE
Fix documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Find the LabOne Q Manual here:
 <https://docs.zhinst.com/labone_q_user_manual/>
 
 Dive right into using LabOne Q and generate your first pulse sequence:
-<https://docs.zhinst.com/labone_q_user_manual/getting_started/hello_world/>
+<https://docs.zhinst.com/labone_q_user_manual/core/getting_started/hello_world.html>
 
 The API Documentation is published here:
-<https://docs.zhinst.com/labone_q_user_manual/reference/simple/>
+<https://docs.zhinst.com/labone_q_user_manual/core/reference/simple.html>
 
 ## Architecture
 


### PR DESCRIPTION
Minor fix for two documentation links in the readme file. Currently, these two links give me a `404 Not Found` error.